### PR TITLE
fix: move babel-runtime to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "babel-preset-flow": "^6.23.0",
     "babel-preset-stage-1": "^6.22.0",
     "babel-register": "^6.23.0",
-    "babel-runtime": "^6.23.0",
     "chai": "^4.1.2",
     "codecov": "^3.0.0",
     "copy": "^0.3.0",
@@ -93,6 +92,7 @@
     "webpack": "^3.8.1"
   },
   "dependencies": {
+    "babel-runtime": "^6.23.0",
     "chalk": "^2.3.0",
     "es6-promisify": "^5.0.0",
     "flow-runtime": "^0.17.0",


### PR DESCRIPTION
fix #20